### PR TITLE
Removed index.html from live deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
                   - node_modules/
                   - src/
                   - templates/
-                  - public/
+                  - public/main.js
                   - pancake/
                   - pancake.scss
                   - package.json

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 Interactive colour template previews for the Design System.
 
-Development preview is located at: https://chameleon.apps.y.cld.gov.au/
-
 ## Prerequisites: 
 - [Node.js](https://nodejs.org/en/download/) 10 or higher prefereably the LTS release, which at the time of writing is `v10.13.0`
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,10 +11,12 @@ const uikitSass = fs.readFileSync( './pancake.scss', 'utf-8' );
 
 app.use(helmet());
 
-// Load the index.html 
+// Static endpoint for testing and main script to be loaded into DS site.
 app.use('/', express.static(path.join(__dirname, '/../public')))
 
+// Static endpoint for templates to be loaded into iframe
 app.use('/templates', express.static(path.join(__dirname, '/../templates/full-page')))
+
 
 app.get("/frame",  async ( req, res ) => {
 


### PR DESCRIPTION
Links to #23 

Removes `index.html` from deployments