### PR TITLE
Whitelist user input

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,6 +182,7 @@ App.get( `${ SETTINGS.endpoint }*`, ( request, response ) => {
 	// Generate HTML to send back to user
 	const html = GenerateHTML( request._parsedUrl.pathname, request.query, SETTINGS.endpoint, SETTINGS.path.templates );
 
+	// Send back the HTML to the user
 	response.send( html );
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5776,6 +5776,11 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
+		"validator": {
+			"version": "10.9.0",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-10.9.0.tgz",
+			"integrity": "sha512-hZJcZSWz9poXBlAkjjcsNAdrZ6JbjD3kWlNjq/+vE7RLLS/+8PAj3qVVwrwsOz/WL8jPmZ1hYkRvtlUeZAm4ug=="
+		},
 		"vary": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
 		"express": "^4.16.4",
 		"gradient-string": "^1.2.0",
 		"helmet": "^3.15.0",
-		"node-sass": "^4.10.0"
+		"node-sass": "^4.10.0",
+		"validator": "^10.9.0"
 	},
 	"devDependencies": {
 		"chai": "^4.2.0",

--- a/test/unit/fixtures/basic/fixture-encoded-xss.html
+++ b/test/unit/fixtures/basic/fixture-encoded-xss.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+    <link rel="stylesheet" href="/assets/css/main.css">
+</head>
+<body>
+<div class="sass-error au-body au-page-alerts au-page-alerts--error">
+					<h1 class="au-display-md">Error</h1>
+					<ul><li>Undefined variable: "$AU-action".</li></ul>
+				</div>
+</body>
+</html>

--- a/test/unit/fixtures/basic/fixture-unencoded-xss.html
+++ b/test/unit/fixtures/basic/fixture-unencoded-xss.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+    <link rel="stylesheet" href="/assets/css/main.css">
+</head>
+<body>
+<div class="sass-error au-body au-page-alerts au-page-alerts--error">
+					<h1 class="au-display-md">Error</h1>
+					<ul><li>Undefined variable: "$AU-action".</li></ul>
+				</div>
+</body>
+</html>

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -142,4 +142,46 @@ Describe( 'GenerateHTML()', () => {
 		Expect( html ).to.equal( html );
 		done();
 	});
+
+	It( 'It should return an error given a typical unencoded XSS query', ( done ) => {
+		const html = GenerateHTML(
+			'/zerella/basic',
+			{ action: '<script>page.alert("hi");</script>' },
+			'/zerella',
+			'test/unit/fixtures',
+			{
+				data:      'body { background: $AU-action; }',
+				variables: { action: '$AU-action', text: '$AU-text' },
+			},
+		);
+		
+		const fixture = Fs.readFileSync(
+			'test/unit/fixtures/basic/fixture-unencoded-xss.html',
+			'utf-8',
+		);
+
+		Expect( html ).to.equal( fixture );
+		done();
+	});
+
+	It( 'It should return an error given a typical encoded XSS query', ( done ) => {
+		const html = GenerateHTML(
+			'/zerella/basic',
+			{ action: 'action=purple</style>.%20<a%20href="https://evil.com"%20target="_blank">Click%20here%20to%20read%20more</a>' },
+			'/zerella',
+			'test/unit/fixtures',
+			{
+				data:      'body { background: $AU-action; }',
+				variables: { action: '$AU-action', text: '$AU-text' },
+			},
+		);
+
+		const fixture = Fs.readFileSync(
+			'test/unit/fixtures/basic/fixture-encoded-xss.html',
+			'utf-8',
+		);
+
+		Expect( html ).to.equal( fixture );
+		done();
+	});
 });


### PR DESCRIPTION
Using `npm/validator` we now whitelist and restrict user input to:

- `characters ( upper and lower)`
- `numbers`
- `%`
- `#` 