### PR TITLE
Remove xss sameorigin for localhost

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,8 @@ App.use( '/templates', Express.static( 'templates' ) );
 // Handle requests to server on route SETTINGS.serverLocation
 App.get( `${ SETTINGS.endpoint }*`, ( request, response ) => {
 	// Removed XSS sameorigin policy for local testing
-	process.env.NODE_ENV == 'production' ? '' : response.removeHeader( 'X-Frame-Options' );
+	process.env.NODE_ENV === 'production' ? '' : response.removeHeader( 'X-Frame-Options' );
+	
 	// Generate HTML to send back to user
 	const html = GenerateHTML( request._parsedUrl.pathname, request.query, SETTINGS.endpoint, SETTINGS.path.templates );
 

--- a/index.js
+++ b/index.js
@@ -172,6 +172,8 @@ App.use( '/templates', Express.static( 'templates' ) );
 
 // Handle requests to server on route SETTINGS.serverLocation
 App.get( `${ SETTINGS.endpoint }*`, ( request, response ) => {
+	// Removed XSS sameorigin policy for local testing
+	process.env.NODE_ENV == 'production' ? '' : response.removeHeader( 'X-Frame-Options' );
 	// Generate HTML to send back to user
 	const html = GenerateHTML( request._parsedUrl.pathname, request.query, SETTINGS.endpoint, SETTINGS.path.templates );
 


### PR DESCRIPTION
Allows devs to use the localhost:3000 src when testing locally