### PR TITLE
Make sure template exists otherwise throw error

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,10 +117,14 @@ const RainbowMessage = ( string ) => {
  */
 const GenerateHTML = ( url, query, endpoint, templateDir, { data, variables } = SETTINGS.sass ) => {
 	// Change endpoint to template location, remove any ../
-	const cleanURL = url.replace( endpoint, templateDir ).replace( '../', '' );
+	const cleanURL = url.replace( /\.\.\//g, '' ).replace( endpoint, templateDir );
 
 	// Location of the index.html file relative to URL.
 	const templateLocation = `${ cleanURL }/index.html`;
+
+	if( !Fs.existsSync( templateLocation ) ) {
+		throw new Error( `Template not found for ${ url }` );
+	}
 
 	// Get the HTML
 	let template = Fs.readFileSync( templateLocation, 'utf-8' );

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ const GenerateHTML = ( url, query, endpoint, templateDir, { data, variables } = 
 	const templateLocation = `${ cleanURL }/index.html`;
 
 	if( !Fs.existsSync( templateLocation ) ) {
-		throw new Error( `Template not found for ${ url }` );
+		throw new Error( `Template not found for ${ Escape( url ) }` );
 	}
 
 	// Get the HTML
@@ -195,7 +195,7 @@ App.get( `${ SETTINGS.endpoint }*`, ( request, response ) => {
 App.listen( SETTINGS.PORT, () => {
 	RainbowMessage( 'Chameleon' );
 	CFonts.say(
-		`Started at http://localhost:${ SETTINGS.PORT }${ SETTINGS.endpoint }`,
+		`🦎 Started at http://localhost:${ SETTINGS.PORT }${ SETTINGS.endpoint } 🦎`,
 		{
 			align: 'center',
 			font:  'console',

--- a/index.js
+++ b/index.js
@@ -171,7 +171,12 @@ App.use( '/assets', Express.static( SETTINGS.path.assets ) );
 App.use( '/templates', Express.static( 'templates' ) );
 
 // Handle requests to server on route SETTINGS.serverLocation
-App.get( `${ SETTINGS.endpoint }/*`, ( request, response ) => {
+App.get( `${ SETTINGS.endpoint }*`, ( request, response ) => {
+	// Removed XSS sameorigin policy for local testing
+	if( process.env.NODE_ENV !== 'production' ) {
+		response.removeHeader( 'X-Frame-Options' );
+	}
+
 	// Generate HTML to send back to user
 	const html = GenerateHTML( request._parsedUrl.pathname, request.query, SETTINGS.endpoint, SETTINGS.path.templates );
 

--- a/index.js
+++ b/index.js
@@ -116,8 +116,11 @@ const RainbowMessage = ( string ) => {
  * @returns {string}             - The HTML to send back to the user
  */
 const GenerateHTML = ( url, query, endpoint, templateDir, { data, variables } = SETTINGS.sass ) => {
+	// Change endpoint to template location, remove any ../
+	const cleanURL = url.replace( endpoint, templateDir ).replace( '../', '' );
+
 	// Location of the index.html file relative to URL.
-	const templateLocation = `${ url.replace( endpoint, templateDir ) }/index.html`;
+	const templateLocation = `${ cleanURL }/index.html`;
 
 	// Get the HTML
 	let template = Fs.readFileSync( templateLocation, 'utf-8' );

--- a/index.js
+++ b/index.js
@@ -171,10 +171,7 @@ App.use( '/assets', Express.static( SETTINGS.path.assets ) );
 App.use( '/templates', Express.static( 'templates' ) );
 
 // Handle requests to server on route SETTINGS.serverLocation
-App.get( `${ SETTINGS.endpoint }*`, ( request, response ) => {
-	// Removed XSS sameorigin policy for local testing
-	process.env.NODE_ENV === 'production' ? '' : response.removeHeader( 'X-Frame-Options' );
-	
+App.get( `${ SETTINGS.endpoint }/*`, ( request, response ) => {
 	// Generate HTML to send back to user
 	const html = GenerateHTML( request._parsedUrl.pathname, request.query, SETTINGS.endpoint, SETTINGS.path.templates );
 


### PR DESCRIPTION
Before a user could hit `../../../` this should stop this.

Fixes #47 