### PR TITLE
Removed links to other template pages for the existing templates

### DIFF
--- a/templates/content/index.html
+++ b/templates/content/index.html
@@ -92,9 +92,9 @@
 									Close
 								</button>
 								<ul class="au-link-list">
-									<li><a href="/chameleon/">Home</a></li>
+									<li><a href="#">Home</a></li>
 									<li class="active"><a href="#" aria-current="page">Content page</a></li>
-									<li><a href="/chameleon/form">Form page</a></li>
+									<li><a href="#">Form page</a></li>
 									<li><a href="#">Simple terms</a></li>
 									<li><a href="#">Distinct from eachother</a></li>
 								</ul>

--- a/templates/form/index.html
+++ b/templates/form/index.html
@@ -93,8 +93,8 @@
 									Close
 								</button>
 								<ul class="au-link-list">
-									<li><a href="/chameleon/">Home</a></li>
-									<li><a href="/chameleon/content">Content page</a></li>
+									<li><a href="#">Home</a></li>
+									<li><a href="#">Content page</a></li>
 									<li class="active"><a href="#" aria-current="page">Form page</a></li>
 									<li><a href="#">Simple terms</a></li>
 									<li><a href="#">Distinct from eachother</a></li>

--- a/templates/index.html
+++ b/templates/index.html
@@ -94,8 +94,8 @@
 								</button>
 								<ul class="au-link-list">
 									<li class="active"><a href="#" aria-current="page">Home</a></li>
-									<li><a href="/chameleon/content">Content page</a></li>
-									<li><a href="/chameleon/form">Form page</a></li>
+									<li><a href="#">Content page</a></li>
+									<li><a href="#">Form page</a></li>
 									<li><a href="#">Simple terms</a></li>
 									<li><a href="#">Distinct from eachother</a></li>
 								</ul>


### PR DESCRIPTION
The `home` template for example shouldn't be able to link to the `content` template