### PR TITLE
Added styles to .sass-error to override page styles

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -111,4 +111,6 @@ form {
 // Custom error for sass
 .sass-error {
 	@include AU-space( margin, 2unit );
+	background-color: #fff;
+	color: #000;
 }


### PR DESCRIPTION
Fix #96 
Could also do a `.nostyle` selector and try stuff like `all: initial` but that would clear ALL styling 😢 