### PR TITLE
Use cloud.gov.au naming convention for env vars in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
                     cd ~/chameleon
                     mv .deploy/manifest-dev.yml .
                     rm -rf node_modules # Node.js buildpack is stupid see: https://github.com/cloudfoundry/nodejs-buildpack/issues/75
-                    cf login -a $CF_API_DEV -o $CF_ORG -s $CF_SPACE -u $CF_USER_DEV -p $CF_PASSWORD_STAGING
+                    cf login -a $CF_API_STAGING -o $CF_ORG -s $CF_SPACE -u $CF_USERNAME -p $CF_PASSWORD_STAGING
                     cf zero-downtime-push chameleon -f manifest-dev.yml
 
 
@@ -60,7 +60,7 @@ jobs:
                     cd ~/chameleon
                     mv .deploy/manifest-prod.yml .
                     rm -rf node_modules # Node.js buildpack is stupid, see: https://github.com/cloudfoundry/nodejs-buildpack/issues/75
-                    cf login -a $CF_API_PROD -o $CF_ORG -s $CF_SPACE -u $CF_USER_PROD -p $CF_PASSWORD_PROD
+                    cf login -a $CF_API_PROD -o $CF_ORG -s $CF_SPACE -u $CF_USERNAME -p $CF_PASSWORD_PROD
                     cf zero-downtime-push chameleon -f manifest-prod.yml
 
 workflows:


### PR DESCRIPTION
cloud.gov.au will start managing this project's CF_* env vars in circleci, and to make it easier for us we need to have a standard naming convention for environment variables across all repos we look after.
Nothing should change for this project, this is really just house cleaning to use the standard names.

The standard naming convention is:
CF_API_PROD
CF_API_STAGING
CF_ORG
CF_PASSWORD_PROD
CF_PASSWORD_STAGING
CF_SPACE
CF_USERNAME

After this has been merged we can remove any CF_* env vars in circleci that arent in the above list.